### PR TITLE
feat(button-icon): add button icon component

### DIFF
--- a/src/components/ButtonIcon/ButtonIcon.jsx
+++ b/src/components/ButtonIcon/ButtonIcon.jsx
@@ -1,0 +1,11 @@
+import s from './ButtonIcon.module.scss';
+
+const ButtonIcon = ({ src, onClick, alt }) => {
+  return (
+    <button onClick={onClick} className={s.buttonIcon}>
+      <img src={src} alt={alt} className={s.icon} />
+    </button>
+  );
+};
+
+export default ButtonIcon;

--- a/src/components/ButtonIcon/ButtonIcon.module.scss
+++ b/src/components/ButtonIcon/ButtonIcon.module.scss
@@ -1,0 +1,19 @@
+@use '../../styles/variables' as vars;
+
+.buttonIcon {
+  width: 50px;
+  height: 50px;
+  border-radius: 15px;
+  border: 1px solid vars.$color-foreground;
+  background: transparent;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .icon {
+    width: 24px;
+    height: 24px;
+    object-fit: contain;
+  }
+}


### PR DESCRIPTION
Adds a reusable ButtonIcon component for icon-based buttons.  
Supports images (SVG/PNG) and centers the icon using Flexbox.
