### PR TITLE
feat(card-event): criação do componente cardEvent

### DIFF
--- a/src/components/CardEvent/CardEvent.jsx
+++ b/src/components/CardEvent/CardEvent.jsx
@@ -1,0 +1,131 @@
+import React, { memo } from "react";
+import { FiCalendar, FiMapPin, FiArrowRight } from "react-icons/fi";
+import { useNavigate } from "react-router-dom";
+import s from "./cardEvent.module.scss";
+
+const normalizeTag = (tag) =>
+  tag
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/\s+/g, "-");
+
+const CardEvent = memo(({ event, variant = "featured" }) => {
+  const isCompact = variant === "compact";
+  const navigate = useNavigate();
+
+  const handleDetails = () => {
+    navigate(`/event/${event.id}`);
+  };
+
+  const cardStyle = {
+    backgroundImage: event.image
+      ? `linear-gradient(to top, rgba(0, 0, 0, 0.8) 0%, transparent 70%), url(${event.image})`
+      : "none",
+  };
+
+  return (
+    <article
+      className={`${s.card} ${isCompact ? s.cardCompact : s.cardFeatured}`}
+      style={cardStyle}
+      aria-labelledby={`event-title-${event.id}`}
+    >
+      {!isCompact && event.tags?.length > 0 && (
+        <div className={s.tags} role="list">
+          {event.tags.map((tag) => (
+            <span
+              key={tag}
+              className={s.tag}
+              data-tag-name={normalizeTag(tag)}
+              role="listitem"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className={s.content}>
+        <h3 id={`event-title-${event.id}`} className={s.title}>
+          {event.title}
+        </h3>
+
+        <div className={s.bottomWrapper}>
+          <div className={s.infoGroup}>
+            <div className={s.infoItem} aria-label={`Data: ${event.date} às ${event.time}`}>
+              <FiCalendar size={20} aria-hidden="true" />
+              <span>{`${event.date} • ${event.time}`}</span>
+            </div>
+
+            <div className={s.infoItem} aria-label={`Local: ${event.location}`}>
+              <FiMapPin size={20} aria-hidden="true" />
+              <span>{event.location}</span>
+            </div>
+          </div>
+
+          {isCompact && (
+            <button
+              className={s.cardIconButton}
+              onClick={handleDetails}
+              type="button"
+              aria-label={`Ver detalhes de ${event.title}`}
+            >
+              <FiArrowRight size={24} aria-hidden="true" />
+            </button>
+          )}
+        </div>
+
+        {!isCompact && (
+          <button
+            className={s.cardButton}
+            onClick={handleDetails}
+            type="button"
+            aria-label={`Ver detalhes de ${event.title}`}
+          >
+            Ver detalhes
+            <FiArrowRight size={20} aria-hidden="true" />
+          </button>
+        )}
+      </div>
+    </article>
+  );
+});
+
+CardEvent.displayName = "CardEvent";
+
+export default CardEvent;
+
+/* ===================================================================
+  EXEMPLO DE USO 
+
+    1. Card Maior (Featured) 
+    
+   <CardEvent 
+          variant="featured"
+          event={{
+            id: 1,
+            title: "Feira Cultural",
+            date: "15 Jan 2025",
+            time: "22:00",
+            location: "Parque Ibirapuera, SP",
+            image: "https://images.unsplash.com/photo-1492684223066-81342ee5ff30",
+            tags: ["Cultural", "Gratis"]
+          }}
+        />
+
+    2. Card Compacto (Compact)
+
+     <CardEvent 
+            variant="compact"
+            event={{
+              id: 2,
+              title: "Festival de Música Eletrônica",
+              date: "15 Jan 2025",
+              time: "22:00",
+              location: "Parque Ibirapuera, SP",
+              image: "https://images.unsplash.com/photo-1475721027785-f74eccf877e2"
+            }}
+          /> 
+
+    =================================================================== */
+     

--- a/src/components/CardEvent/cardEvent.module.scss
+++ b/src/components/CardEvent/cardEvent.module.scss
@@ -1,20 +1,20 @@
 @use "../../styles/variables" as v;
 
-$tag-colors: (
-  "cultural": #12c299,
-  "gratis": v.$color-acent,
+$tag-colors: (  
+  "gratis":#4caf50, 
   "pago": #ff4d4d,
-  "shows": #7c3aed,
-  "artes": #bd00ff,
-  "games": #121793,
-  "stand-up": #ff5722,
-  "comedia": #c9b92d,
-  "networking": #03655c,
-  "festas": #4caf50,
-  "food": #795548,
-  "workshop": #3f51b5,
-  "tech": #0f172a,
-  "musica": #ff8c00
+  // "cultural": #12c299,
+  // "shows": #7c3aed,
+  // "artes": #bd00ff,
+  // "games": #121793,
+  // "stand-up": #ff5722,
+  // "comedia": #c9b92d,
+  // "networking": #03655c,
+  // "festas": v.$color-acent,
+  // "food": #795548,
+  // "workshop": #3f51b5,
+  // "tech": #0f172a,
+  // "musica": #ff8c00
 );
 
 .card {
@@ -25,20 +25,30 @@ $tag-colors: (
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
+  font-family: "Archivo", sans-serif;
   padding: 1.5rem;
   overflow: hidden;
+  box-sizing: border-box;
   border: 1px solid v.$color-foreground;
   transition: transform 0.3s ease, border-color 0.3s ease;
   width: 100%; 
-
+  
   &:hover {
     transform: translateY(-5px); 
-  }
+  }  
 }
 
 .cardFeatured {
   width: 380px; 
-  height: 480px; 
+  height: 480px;
+  
+  a, button, .buttonLink { 
+   display: flex;
+   justify-content: center;
+   width: 100%;
+   box-sizing: border-box;
+   margin-top: 1rem;
+  }
 
   @media (max-width: 1024px) {
     width: 340px; 
@@ -55,6 +65,10 @@ $tag-colors: (
   width: 480px; 
   height: 232px; 
 
+  a[href*="/event/"] {
+    text-decoration: none;
+}
+
   @media (max-width: 1024px) {
     width: 400px; 
     height: 210px;
@@ -70,14 +84,15 @@ $tag-colors: (
 
 .content {
   position: relative;
-  z-index: 2;
+  z-index: 2;    
+  color: v.$color-foreground;
+ 
 }
 
 .title {
   font-size: 1.6rem; 
-  margin-bottom: 0.75rem;
-  color: v.$color-foreground;
-  font-weight: 700;
+  margin-bottom: 0.75rem;  
+  font-weight: 700;  
 
   @media (max-width: 1024px) {
     font-size: 1.4rem;
@@ -91,13 +106,13 @@ $tag-colors: (
 .bottomWrapper {
   display: flex;
   justify-content: space-between;
-  align-items: flex-end;
+  align-items: flex-end; 
 }
 
 .infoGroup {
   display: flex;
   flex-direction: column; 
-  gap: 0.5rem;
+  gap: 0.5rem; 
 
  @media (max-width: 1024px) {
     font-size: 1rem;
@@ -124,11 +139,10 @@ $tag-colors: (
 
 .tags {
   position: absolute;
-  top: 1.5rem;
-  left: 1.5rem;
+  top: 1.5rem;  
   right: 1.5rem;
   display: flex;
-  justify-content: space-between; 
+  justify-content: flex-end;
   z-index: 2;
 }
 
@@ -144,45 +158,5 @@ $tag-colors: (
       background-color: $color;
       color: v.$color-foreground;
     }
-  }
-}
-
-.cardButton {
-  width: 100%;
-  margin-top: 1.5rem;
-  padding: 14px 34px;
-  border-radius: 12px;
-  background-color: v.$color-primary;
-  color: v.$color-background;
-  border: none;
-  font-weight: 600;
-  font-size: 1rem; 
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 0.5rem;
-  cursor: pointer; 
-
-  &:hover {   
-    background-color: v.$color-primary-hover; 
-  }
-}
-
-.cardIconButton {
-  width: 50px; 
-  height: 50px; 
-  border-radius: 14px;
-  background-color: transparent;
-  color: v.$color-foreground;
-  border: 1px solid v.$color-foreground;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer; 
-
-  &:hover {
-    border-color: v.$color-primary;
-    color: v.$color-primary;
-    background-color: rgba(v.$color-primary, 0.1);
   }
 }

--- a/src/components/CardEvent/cardEvent.module.scss
+++ b/src/components/CardEvent/cardEvent.module.scss
@@ -1,0 +1,188 @@
+@use "../../styles/variables" as v;
+
+$tag-colors: (
+  "cultural": #12c299,
+  "gratis": v.$color-acent,
+  "pago": #ff4d4d,
+  "shows": #7c3aed,
+  "artes": #bd00ff,
+  "games": #121793,
+  "stand-up": #ff5722,
+  "comedia": #c9b92d,
+  "networking": #03655c,
+  "festas": #4caf50,
+  "food": #795548,
+  "workshop": #3f51b5,
+  "tech": #0f172a,
+  "musica": #ff8c00
+);
+
+.card {
+  position: relative;
+  border-radius: 20px;
+  background-size: cover;
+  background-position: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 1.5rem;
+  overflow: hidden;
+  border: 1px solid v.$color-foreground;
+  transition: transform 0.3s ease, border-color 0.3s ease;
+  width: 100%; 
+
+  &:hover {
+    transform: translateY(-5px); 
+  }
+}
+
+.cardFeatured {
+  width: 380px; 
+  height: 480px; 
+
+  @media (max-width: 1024px) {
+    width: 340px; 
+    height: 440px;
+  }
+
+  @media (max-width: 480px) {
+    width: 100%;
+    height: 400px; 
+  }
+}
+
+.cardCompact {
+  width: 480px; 
+  height: 232px; 
+
+  @media (max-width: 1024px) {
+    width: 400px; 
+    height: 210px;
+  }
+
+  @media (max-width: 480px) {
+    width: 100%;
+    height: auto; 
+    min-height: 200px;
+    padding: 1rem; 
+  }
+}
+
+.content {
+  position: relative;
+  z-index: 2;
+}
+
+.title {
+  font-size: 1.6rem; 
+  margin-bottom: 0.75rem;
+  color: v.$color-foreground;
+  font-weight: 700;
+
+  @media (max-width: 1024px) {
+    font-size: 1.4rem;
+  }
+
+  @media (max-width: 480px) {
+    font-size: 1.2rem; 
+  }
+}
+
+.bottomWrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+
+.infoGroup {
+  display: flex;
+  flex-direction: column; 
+  gap: 0.5rem;
+
+ @media (max-width: 1024px) {
+    font-size: 1rem;
+  }
+
+  @media (max-width: 480px) {
+    font-size: 0.8rem; 
+  }
+}
+
+.infoItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;   
+
+  &:first-child svg {
+    color: v.$color-primary; 
+  }
+
+  &:last-child svg {
+    color: v.$color-acent; 
+  }
+}
+
+.tags {
+  position: absolute;
+  top: 1.5rem;
+  left: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  justify-content: space-between; 
+  z-index: 2;
+}
+
+.tag {
+  padding: 6px 16px;
+  border-radius: 8px;
+  font-size: 1rem; 
+  background-color: v.$color-foreground; 
+  color: v.$color-background;
+
+  @each $name, $color in $tag-colors {
+    &[data-tag-name="#{$name}"] {
+      background-color: $color;
+      color: v.$color-foreground;
+    }
+  }
+}
+
+.cardButton {
+  width: 100%;
+  margin-top: 1.5rem;
+  padding: 14px 34px;
+  border-radius: 12px;
+  background-color: v.$color-primary;
+  color: v.$color-background;
+  border: none;
+  font-weight: 600;
+  font-size: 1rem; 
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer; 
+
+  &:hover {   
+    background-color: v.$color-primary-hover; 
+  }
+}
+
+.cardIconButton {
+  width: 50px; 
+  height: 50px; 
+  border-radius: 14px;
+  background-color: transparent;
+  color: v.$color-foreground;
+  border: 1px solid v.$color-foreground;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer; 
+
+  &:hover {
+    border-color: v.$color-primary;
+    color: v.$color-primary;
+    background-color: rgba(v.$color-primary, 0.1);
+  }
+}


### PR DESCRIPTION
Criação do componente reutilizável CardEvent com suporte às variantes featured e compact. 

Reduzi as dimensões dos cards em relação às medidas do Figma, pois estava ficando muito grande, então mantive os tamanhos próximos e proporcionais. 
Incluí as categorias das tags que visualizei no Figma como exemplo no componente.
Adicionei também um guia de "Exemplo de Uso" comentado ao final do arquivo.

<img width="379" height="454" alt="image" src="https://github.com/user-attachments/assets/6801e575-6073-475f-b019-579b8c4d18e5" />

<img width="472" height="222" alt="image" src="https://github.com/user-attachments/assets/ee978f47-156f-4b6f-ab8d-9568f8913ff7" />
